### PR TITLE
Enable C++ and Golang builds in the Devcontainer + DinD stub

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,23 @@
-FROM python:3.10.4-slim-buster
+FROM debian:bookworm-20250317
 
 RUN apt-get update
-RUN apt-get install -y libsass-dev build-essential libcairo2 git libpango-1.0-0 libpangoft2-1.0-0 pangocairo-1.0 pngquant
+RUN apt-get install -y \
+    build-essential git checkinstall libssl-dev openssl software-properties-common \
+    cmake golang-go \
+    python3.11 python3-pip python3.11-venv libsass-dev libcairo2 libpango-1.0-0 libpangoft2-1.0-0 pangocairo-1.0 pngquant \
+    sudo
+
+## vscode user
+RUN useradd -ms /bin/bash vscode \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo vscode ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/vscode \
+    && chmod 0440 /etc/sudoers.d/vscode
+
+USER vscode
+WORKDIR /home/vscode
+
+## Python will run in venv
+RUN python3 -m venv /home/vscode/venv
+ENV PATH="/home/vscode/venv/bin:$PATH"
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,12 @@
 {
     "name": "Material for MkDocs",
     "dockerFile": "Dockerfile",
+//    "features": {
+//        "ghcr.io/devcontainers/features/docker-in-docker:2.12.1": {
+//            "version": "latest",
+//            "moby": true
+//        }
+    },
     "customizations": {
       "vscode": {
         // Set *default* container specific settings.json values on container create.
@@ -11,6 +17,7 @@
         },
         // Add the IDs of extensions you want installed when the container is created.
         "extensions": [
+          "streetsidesoftware.code-spell-checker",
           "yzhang.markdown-all-in-one",
           "redhat.vscode-yaml",
           "shardulm94.trailing-spaces",
@@ -23,8 +30,10 @@
     "forwardPorts": [
       8000
     ],
-    // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "pip3 install -r .devcontainer/requirements.txt "
-    // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-    //"remoteUser": "vscode"
+    "remoteUser": "vscode",
+    // Updates cache on new container runs
+    "postCreateCommand": "pip3 install -r .devcontainer/requirements.txt",
+    // Docker-in-Docker for testing
+  //  "runArgs": ["--init", "--privileged"],
+  //  "overrideCommand": false
   }

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,7 @@
+version: "0.2"
+ignorePaths: []
+dictionaryDefinitions: []
+dictionaries: []
+words: []
+ignoreWords: []
+import: []


### PR DESCRIPTION
Enables Golang and CMake builds inside the Devcontainer.
For testing purposes, DinD configuration needs to be finalized


