### PR TITLE
Contributing: Add Github Codespaces usage documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,6 +44,13 @@
           "ms-azuretools.vscode-docker"
         ],
       },
+      // Configure properties specific to Codespaces.
+	    "codespaces": {
+		     "openFiles": [
+			     "README.md",
+			     "CONTRIBUTING.md"
+		   ]
+	    }
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,10 @@ You can use one of the following developer environments:
 
 * [Dev Containers](.devcontainer/README.md) - for local development, testing,
   and also for the documentation site development.
-* Nix
+* GitHub Codespaces (with a Dev Containers)
+* Experimental: Nix
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/testcontainers/testcontainers-native)
 
 ## Community Slack
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ The best support is investing some time in the project.
 All contributions are welcome, checkout the [Contributor Guide](./CONTRIBUTING.md).
 Of course, [GitHub Sponsorships](https://github.com/sponsors/oleg-nenashev) will be appreciated too.
 
+## Contributing
+
+Any contributions are welcome!
+See the [Contributor Guide](./CONTRIBUTING.md).
+
 ## Read More
 
 - [Testcontainers](https://testcontainers.org/)


### PR DESCRIPTION
Yes, we can use GitHub Actions as a CDE for this repository