### PR TITLE
Remove on-agent build job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build-project:
-    name: Build (Native)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v3.5.3
-
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.13
-        with:
-          # We need recent version with support for WORKING_DIRECTORY in add_test()
-          cmake-version: '3.27.6'
-
-      - name: Run CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          run-build: true
-          run-test: true
-          test-args: "--output-on-failure"
-
   build-project-devcontainers:
     name: Build (Dev Containers)
     runs-on: ubuntu-latest


### PR DESCRIPTION
With a Dev Container being in place, there is no need in a local build... especially after the additional Postgres dependency in #41 that requires extra packages

Later, we should add a Nix build, though

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
